### PR TITLE
냉장고 목록 조회 기능 no offset 적용

### DIFF
--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/application/RefrigeratorService.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/application/RefrigeratorService.java
@@ -20,7 +20,6 @@ import com.icebox.freshmate.domain.refrigerator.domain.Refrigerator;
 import com.icebox.freshmate.domain.refrigerator.domain.RefrigeratorRepository;
 import com.icebox.freshmate.domain.member.domain.Member;
 import com.icebox.freshmate.domain.member.domain.MemberRepository;
-import com.icebox.freshmate.domain.refrigerator.domain.RefrigeratorSortType;
 import com.icebox.freshmate.global.error.ErrorCode;
 import com.icebox.freshmate.global.error.exception.BusinessException;
 import com.icebox.freshmate.global.error.exception.EntityNotFoundException;
@@ -59,19 +58,7 @@ public class RefrigeratorService {
 
 		LocalDateTime lastUpdatedAt = getLastPageUpdatedAt(lastPageUpdatedAt);
 
-		RefrigeratorSortType refrigeratorSortType = RefrigeratorSortType.findRefrigeratorSortType(sortBy);
-		Slice<Refrigerator> refrigerators = null;
-
-		switch (refrigeratorSortType) {
-			case NAME_ASC ->
-				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByNameAsc(member.getId(), pageable, lastPageName, lastUpdatedAt);
-			case NAME_DESC ->
-				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByNameDesc(member.getId(), pageable, lastPageName, lastUpdatedAt);
-			case UPDATED_AT_ASC ->
-				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByUpdatedAtAsc(member.getId(), pageable, lastUpdatedAt);
-			case UPDATED_AT_DESC ->
-				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByUpdatedAtDesc(member.getId(), pageable, lastUpdatedAt);
-		}
+		Slice<Refrigerator> refrigerators = refrigeratorRepository.findAllByMemberIdOrderBySortCondition(member.getId(), pageable, lastPageName, lastUpdatedAt, sortBy);
 
 		return RefrigeratorsRes.from(refrigerators);
 	}

--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/application/RefrigeratorService.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/application/RefrigeratorService.java
@@ -68,7 +68,7 @@ public class RefrigeratorService {
 			case NAME_DESC ->
 				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByNameDesc(member.getId(), pageable, lastPageName, LastUpdatedAt);
 			case UPDATED_AT_ASC ->
-				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByUpdatedAtAsc(member.getId(), pageable);
+				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByUpdatedAtAsc(member.getId(), pageable, LastUpdatedAt);
 			case UPDATED_AT_DESC ->
 				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByUpdatedAtDesc(member.getId(), pageable);
 		}

--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/application/RefrigeratorService.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/application/RefrigeratorService.java
@@ -66,7 +66,7 @@ public class RefrigeratorService {
 			case NAME_ASC ->
 				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByNameAsc(member.getId(), pageable, lastPageName, LastUpdatedAt);
 			case NAME_DESC ->
-				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByNameDesc(member.getId(), pageable);
+				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByNameDesc(member.getId(), pageable, lastPageName, LastUpdatedAt);
 			case UPDATED_AT_ASC ->
 				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByUpdatedAtAsc(member.getId(), pageable);
 			case UPDATED_AT_DESC ->

--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/application/RefrigeratorService.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/application/RefrigeratorService.java
@@ -57,20 +57,20 @@ public class RefrigeratorService {
 	public RefrigeratorsRes findAll(String sortBy, Pageable pageable, String lastPageName, String lastPageUpdatedAt, String username) {
 		Member member = getMemberByUsername(username);
 
-		LocalDateTime LastUpdatedAt = getLastPageUpdatedAt(lastPageUpdatedAt);
+		LocalDateTime lastUpdatedAt = getLastPageUpdatedAt(lastPageUpdatedAt);
 
 		RefrigeratorSortType refrigeratorSortType = RefrigeratorSortType.findRefrigeratorSortType(sortBy);
 		Slice<Refrigerator> refrigerators = null;
 
 		switch (refrigeratorSortType) {
 			case NAME_ASC ->
-				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByNameAsc(member.getId(), pageable, lastPageName, LastUpdatedAt);
+				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByNameAsc(member.getId(), pageable, lastPageName, lastUpdatedAt);
 			case NAME_DESC ->
-				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByNameDesc(member.getId(), pageable, lastPageName, LastUpdatedAt);
+				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByNameDesc(member.getId(), pageable, lastPageName, lastUpdatedAt);
 			case UPDATED_AT_ASC ->
-				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByUpdatedAtAsc(member.getId(), pageable, LastUpdatedAt);
+				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByUpdatedAtAsc(member.getId(), pageable, lastUpdatedAt);
 			case UPDATED_AT_DESC ->
-				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByUpdatedAtDesc(member.getId(), pageable);
+				refrigerators = refrigeratorRepository.findAllByMemberIdOrderByUpdatedAtDesc(member.getId(), pageable, lastUpdatedAt);
 		}
 
 		return RefrigeratorsRes.from(refrigerators);

--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryCustom.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryCustom.java
@@ -7,11 +7,11 @@ import org.springframework.data.domain.Slice;
 
 public interface RefrigeratorRepositoryCustom {
 
-	Slice<Refrigerator> findAllByMemberIdOrderByNameAsc(Long memberId, Pageable pageable, String lastPageName, LocalDateTime lastUpdatedAt);
+	Slice<Refrigerator> findAllByMemberIdOrderByNameAsc(Long memberId, Pageable pageable, String lastPageName, LocalDateTime lastPageUpdatedAt);
 
-	Slice<Refrigerator> findAllByMemberIdOrderByNameDesc(Long memberId, Pageable pageable, String lastPageName, LocalDateTime lastUpdatedAt);
+	Slice<Refrigerator> findAllByMemberIdOrderByNameDesc(Long memberId, Pageable pageable, String lastPageName, LocalDateTime lastPageUpdatedAt);
 
-	Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtAsc(Long memberId, Pageable pageable);
+	Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtAsc(Long memberId, Pageable pageable, LocalDateTime lastPageUpdatedAt);
 
 	Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtDesc(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryCustom.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryCustom.java
@@ -9,7 +9,7 @@ public interface RefrigeratorRepositoryCustom {
 
 	Slice<Refrigerator> findAllByMemberIdOrderByNameAsc(Long memberId, Pageable pageable, String lastPageName, LocalDateTime lastUpdatedAt);
 
-	Slice<Refrigerator> findAllByMemberIdOrderByNameDesc(Long memberId, Pageable pageable);
+	Slice<Refrigerator> findAllByMemberIdOrderByNameDesc(Long memberId, Pageable pageable, String lastPageName, LocalDateTime lastUpdatedAt);
 
 	Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtAsc(Long memberId, Pageable pageable);
 

--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryCustom.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryCustom.java
@@ -13,5 +13,5 @@ public interface RefrigeratorRepositoryCustom {
 
 	Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtAsc(Long memberId, Pageable pageable, LocalDateTime lastPageUpdatedAt);
 
-	Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtDesc(Long memberId, Pageable pageable);
+	Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtDesc(Long memberId, Pageable pageable, LocalDateTime lastPageUpdatedAt);
 }

--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryCustom.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryCustom.java
@@ -7,11 +7,5 @@ import org.springframework.data.domain.Slice;
 
 public interface RefrigeratorRepositoryCustom {
 
-	Slice<Refrigerator> findAllByMemberIdOrderByNameAsc(Long memberId, Pageable pageable, String lastPageName, LocalDateTime lastPageUpdatedAt);
-
-	Slice<Refrigerator> findAllByMemberIdOrderByNameDesc(Long memberId, Pageable pageable, String lastPageName, LocalDateTime lastPageUpdatedAt);
-
-	Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtAsc(Long memberId, Pageable pageable, LocalDateTime lastPageUpdatedAt);
-
-	Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtDesc(Long memberId, Pageable pageable, LocalDateTime lastPageUpdatedAt);
+	Slice<Refrigerator> findAllByMemberIdOrderBySortCondition(Long memberId, Pageable pageable, String lastPageName, LocalDateTime lastPageUpdatedAt, String sortBy);
 }

--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryImpl.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryImpl.java
@@ -24,9 +24,8 @@ public class RefrigeratorRepositoryImpl implements RefrigeratorRepositoryCustom 
 			.from(refrigerator)
 			.where(
 				refrigerator.member.id.eq(memberId),
-				liRefrigeratorNameAndUpdatedAt(name, updatedAt))
+				gtRefrigeratorNameAndLtUpdatedAt(name, updatedAt))
 			.orderBy(refrigerator.name.asc(), refrigerator.updatedAt.desc())
-			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
 
@@ -83,12 +82,18 @@ public class RefrigeratorRepositoryImpl implements RefrigeratorRepositoryCustom 
 		return new SliceImpl<>(refrigerators, pageable, hasNext);
 	}
 
-	private BooleanExpression liRefrigeratorNameAndUpdatedAt(String name, LocalDateTime updatedAt) {
+	private BooleanExpression gtRefrigeratorNameAndLtUpdatedAt(String name, LocalDateTime updatedAt) {
 		if (name == null || updatedAt == null) {
 			return null;
 		}
 
-		return refrigerator.name.gt(name)
-			.and(refrigerator.updatedAt.gt(updatedAt));
+		BooleanExpression predicate = refrigerator.name.gt(name);
+
+		predicate = predicate.or(
+			refrigerator.name.eq(name)
+				.and(refrigerator.updatedAt.lt(updatedAt))
+		);
+
+		return predicate;
 	}
 }

--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryImpl.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryImpl.java
@@ -64,12 +64,14 @@ public class RefrigeratorRepositoryImpl implements RefrigeratorRepositoryCustom 
 	}
 
 	@Override
-	public Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtDesc(Long memberId, Pageable pageable) {
+	public Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtDesc(Long memberId, Pageable pageable, LocalDateTime lastPageUpdatedAt) {
 		List<Refrigerator> refrigerators = queryFactory.select(refrigerator)
 			.from(refrigerator)
-			.where(refrigerator.member.id.eq(memberId))
+			.where(
+				refrigerator.member.id.eq(memberId),
+				ltRefrigeratorUpdatedAt(lastPageUpdatedAt)
+			)
 			.orderBy(refrigerator.updatedAt.desc())
-			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
 
@@ -123,5 +125,13 @@ public class RefrigeratorRepositoryImpl implements RefrigeratorRepositoryCustom 
 		}
 
 		return refrigerator.updatedAt.gt(updatedAt);
+	}
+
+	private BooleanExpression ltRefrigeratorUpdatedAt(LocalDateTime updatedAt) {
+		if (updatedAt == null) {
+			return null;
+		}
+
+		return refrigerator.updatedAt.lt(updatedAt);
 	}
 }

--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryImpl.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryImpl.java
@@ -19,12 +19,12 @@ public class RefrigeratorRepositoryImpl implements RefrigeratorRepositoryCustom 
 	private QRefrigerator refrigerator = QRefrigerator.refrigerator;
 
 	@Override
-	public Slice<Refrigerator> findAllByMemberIdOrderByNameAsc(Long memberId, Pageable pageable, String name, LocalDateTime updatedAt) {
+	public Slice<Refrigerator> findAllByMemberIdOrderByNameAsc(Long memberId, Pageable pageable, String lastPageName, LocalDateTime lastPageUpdatedAt) {
 		List<Refrigerator> refrigerators = queryFactory.select(refrigerator)
 			.from(refrigerator)
 			.where(
 				refrigerator.member.id.eq(memberId),
-				gtRefrigeratorNameAndLtUpdatedAt(name, updatedAt)
+				gtRefrigeratorNameAndLtUpdatedAt(lastPageName, lastPageUpdatedAt)
 			)
 			.orderBy(refrigerator.name.asc(), refrigerator.updatedAt.desc())
 			.limit(pageable.getPageSize() + 1)
@@ -34,12 +34,12 @@ public class RefrigeratorRepositoryImpl implements RefrigeratorRepositoryCustom 
 	}
 
 	@Override
-	public Slice<Refrigerator> findAllByMemberIdOrderByNameDesc(Long memberId, Pageable pageable, String name, LocalDateTime updatedAt) {
+	public Slice<Refrigerator> findAllByMemberIdOrderByNameDesc(Long memberId, Pageable pageable, String lastPageName, LocalDateTime lastPageUpdatedAt) {
 		List<Refrigerator> refrigerators = queryFactory.select(refrigerator)
 			.from(refrigerator)
 			.where(
 				refrigerator.member.id.eq(memberId),
-				ltRefrigeratorNameAndLtUpdatedAt(name, updatedAt)
+				ltRefrigeratorNameAndLtUpdatedAt(lastPageName, lastPageUpdatedAt)
 			)
 			.orderBy(refrigerator.name.desc(), refrigerator.updatedAt.desc())
 			.limit(pageable.getPageSize() + 1)
@@ -49,12 +49,14 @@ public class RefrigeratorRepositoryImpl implements RefrigeratorRepositoryCustom 
 	}
 
 	@Override
-	public Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtAsc(Long memberId, Pageable pageable) {
+	public Slice<Refrigerator> findAllByMemberIdOrderByUpdatedAtAsc(Long memberId, Pageable pageable, LocalDateTime lastPageUpdatedAt) {
 		List<Refrigerator> refrigerators = queryFactory.select(refrigerator)
 			.from(refrigerator)
-			.where(refrigerator.member.id.eq(memberId))
+			.where(
+				refrigerator.member.id.eq(memberId),
+				gtRefrigeratorUpdatedAt(lastPageUpdatedAt)
+			)
 			.orderBy(refrigerator.updatedAt.asc())
-			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
 
@@ -113,5 +115,13 @@ public class RefrigeratorRepositoryImpl implements RefrigeratorRepositoryCustom 
 		);
 
 		return predicate;
+	}
+
+	private BooleanExpression gtRefrigeratorUpdatedAt(LocalDateTime updatedAt) {
+		if (updatedAt == null) {
+			return null;
+		}
+
+		return refrigerator.updatedAt.gt(updatedAt);
 	}
 }

--- a/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryImpl.java
+++ b/src/main/java/com/icebox/freshmate/domain/refrigerator/domain/RefrigeratorRepositoryImpl.java
@@ -24,7 +24,8 @@ public class RefrigeratorRepositoryImpl implements RefrigeratorRepositoryCustom 
 			.from(refrigerator)
 			.where(
 				refrigerator.member.id.eq(memberId),
-				gtRefrigeratorNameAndLtUpdatedAt(name, updatedAt))
+				gtRefrigeratorNameAndLtUpdatedAt(name, updatedAt)
+			)
 			.orderBy(refrigerator.name.asc(), refrigerator.updatedAt.desc())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
@@ -33,12 +34,14 @@ public class RefrigeratorRepositoryImpl implements RefrigeratorRepositoryCustom 
 	}
 
 	@Override
-	public Slice<Refrigerator> findAllByMemberIdOrderByNameDesc(Long memberId, Pageable pageable) {
+	public Slice<Refrigerator> findAllByMemberIdOrderByNameDesc(Long memberId, Pageable pageable, String name, LocalDateTime updatedAt) {
 		List<Refrigerator> refrigerators = queryFactory.select(refrigerator)
 			.from(refrigerator)
-			.where(refrigerator.member.id.eq(memberId))
+			.where(
+				refrigerator.member.id.eq(memberId),
+				ltRefrigeratorNameAndLtUpdatedAt(name, updatedAt)
+			)
 			.orderBy(refrigerator.name.desc(), refrigerator.updatedAt.desc())
-			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
 
@@ -88,6 +91,21 @@ public class RefrigeratorRepositoryImpl implements RefrigeratorRepositoryCustom 
 		}
 
 		BooleanExpression predicate = refrigerator.name.gt(name);
+
+		predicate = predicate.or(
+			refrigerator.name.eq(name)
+				.and(refrigerator.updatedAt.lt(updatedAt))
+		);
+
+		return predicate;
+	}
+
+	private BooleanExpression ltRefrigeratorNameAndLtUpdatedAt(String name, LocalDateTime updatedAt) {
+		if (name == null || updatedAt == null) {
+			return null;
+		}
+
+		BooleanExpression predicate = refrigerator.name.lt(name);
 
 		predicate = predicate.or(
 			refrigerator.name.eq(name)

--- a/src/main/java/com/icebox/freshmate/global/error/ErrorCode.java
+++ b/src/main/java/com/icebox/freshmate/global/error/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
 	//냉장고
 	NOT_FOUND_REFRIGERATOR("R001", "냉장고가 존재하지 않습니다."),
 	INVALID_REFRIGERATOR_SORT_TYPE("ROO2", "유효하지 않은 냉장고 정렬 타입 입니다."),
+	INVALID_LAST_PAGE_UPDATED_AT_FORMAT("R003", "유효하지 않은 이전 페이지의 수정 날짜 형식입니다."),
 
 	//냉장고 저장소
 	INVALID_STORAGE_TYPE("S001", "유효하지 않은 냉장고 저장소 타입입니다."),


### PR DESCRIPTION
issue #66 

- 100만 개 데이터 기준 마지막 페이지 조회 지연 시간이 첫 페이지 조회 지연 시간보다 약 7초 더 소요되는 문제를 해결했습니다.

- No offset 방식을 적용하여 이전 페이지 전체를 건너뛰어 첫 페이지를 읽은 것과 동일한 성능을 내도록 했습니다.

<img width="536" alt="1" src="https://github.com/hyee0715/freshmate/assets/59169881/bedcdacd-0c31-49f5-81b3-5d2216ed6a17">

- Jmeter에서 위 api로 냉장고 목록 조회 요청을 보냅니다.

### no offset 적용 전 (offset 방식)
- 첫 페이지 조회 응답 지연 시간 : 29ms
<img width="353" alt="29" src="https://github.com/hyee0715/freshmate/assets/59169881/db4c9b2b-8e93-4cd4-9de2-5eb62fab782d">

<br>


- 마지막 페이지 조회 응답 지연 시간 : 7204ms
<img width="351" alt="7204" src="https://github.com/hyee0715/freshmate/assets/59169881/1de39b24-58b8-4919-9096-edc32a7eccd6">

<br>


- Postman을 이용한 마지막 페이지 조회 응답 지연 시간 : 7.64s
<img width="617" alt="2" src="https://github.com/hyee0715/freshmate/assets/59169881/8443a7b0-e900-4bf6-995a-cbc1782ad273">

<br>

### no offset 적용 후

- 마지막 페이지 조회 응답 지연 시간 : 27ms
<img width="354" alt="27" src="https://github.com/hyee0715/freshmate/assets/59169881/67d7bafc-0d9b-42af-bf5a-48f1b9e631dc">

<br>

- Postman을 이용한 마지막 페이지 조회 응답 지연 시간 : 29ms

<img width="617" alt="제목 없음" src="https://github.com/hyee0715/freshmate/assets/59169881/e931b9d5-34e7-4ab4-8bff-68f749f672b1">


- 첫 페이지를 제외한 페이지 조회 시 `last-page-name` 과 `last-page-updated-at` 쿼리 스트링에 각각 이전 페이지 마지막 응답 데이터의 refrigeratorName과 updatedAt 값을 추가하여 요청을 보내야 합니다.
 - 마지막 페이지 조회 시 응답 지연 시간이 7204ms에서 27ms로 줄여 약 99.62% 개선되었습니다.